### PR TITLE
Feature/#6 collective UUID in url

### DIFF
--- a/payshare/purchases/static/client/src/App.vue
+++ b/payshare/purchases/static/client/src/App.vue
@@ -284,7 +284,7 @@ export default {
       if (confirmed) {
         const key = this.collective.key
         this.$store.commit('RESET_ALL')
-        this.$router.push('/' + key)
+        this.$router.push('/unknown')
       }
     },
     reloadPage() {

--- a/payshare/purchases/static/client/src/App.vue
+++ b/payshare/purchases/static/client/src/App.vue
@@ -265,6 +265,11 @@ export default {
     rememberCollective() {
       this.$store.commit('LOAD_COLLECTIVE_FROM_LOCALSTORAGE')
       if (this.collective) {
+
+        if (this.collective.key !== this.uuid) {
+          this.onFailureExitApp()
+        }
+
         // It may be outdated, get a fresh dataset from the API.
         this.$store.dispatch('RETRIEVE_COLLECTIVE_USING_TOKEN')
       }

--- a/payshare/purchases/static/client/src/components/Liquidation.vue
+++ b/payshare/purchases/static/client/src/components/Liquidation.vue
@@ -67,6 +67,7 @@
         </v-layout>
       </v-layout>
       <transfer-actionbar
+        class="pb-1"
         :allow-edit="allowEdit"
         :transfer="transfer"
       />

--- a/payshare/purchases/static/client/src/components/MiniReaction.vue
+++ b/payshare/purchases/static/client/src/components/MiniReaction.vue
@@ -17,7 +17,7 @@
     <div v-if="expanded"
          class="ml-1 caption">
       {{ username }}
-      <v-icon v-if="reaction.member === selectedMember.id"
+      <v-icon v-if="selectedMember && (reaction.member === selectedMember.id)"
               color="red"
               small
               class="clickable"

--- a/payshare/purchases/static/client/src/components/Purchase.vue
+++ b/payshare/purchases/static/client/src/components/Purchase.vue
@@ -42,6 +42,7 @@
         </v-layout>
       </v-layout>
       <transfer-actionbar
+        class="pb-1"
         :allow-edit="allowEdit"
         :transfer="transfer"
       />

--- a/payshare/purchases/static/client/src/router.js
+++ b/payshare/purchases/static/client/src/router.js
@@ -16,7 +16,7 @@ const router = new Router({
       component: Unknown
     },
     {
-      path: '/transfers',
+      path: '/:key/transfers',
       name: 'transfers',
       component: Transfers,
     },

--- a/payshare/purchases/static/client/src/store.js
+++ b/payshare/purchases/static/client/src/store.js
@@ -25,6 +25,7 @@ const getInitialState = () => {
       results: [],
     },
     previousCollectiveKeys: [],
+    collectiveNameByKey: {},
   }
 }
 
@@ -55,6 +56,18 @@ const store = new Vuex.Store({
         }
       }
     },
+    PUT_COLLECTIVE_NAME_BY_KEY_TO_LOCALSTORAGE(state, collective) {
+      let dataString = localStorage.getItem('collectiveKeyToName')
+      let data = JSON.parse(dataString) || {}
+      data[collective.key] = collective.name
+      dataString = JSON.stringify(data)
+      localStorage.setItem('collectiveKeyToName', dataString)
+    },
+    LOAD_COLLECTIVE_NAME_BY_KEY_MAP_FROM_LOCALSTORAGE(state) {
+      const dataString = localStorage.getItem('collectiveKeyToName')
+      const data = JSON.parse(dataString) || {}
+      state.collectiveNameByKey = data
+    },
     LOAD_COLLECTIVE_FROM_LOCALSTORAGE(state) {
       const collectiveString = localStorage.getItem('collective')
       if (collectiveString) {
@@ -68,7 +81,8 @@ const store = new Vuex.Store({
       state.collective = collective
       localStorage.setItem('collective', JSON.stringify(collective))
       if (state.collective) {
-        this.commit('PUT_COLLECTIVE_KEY_TO_LOCALSTORAGE', collective.key)
+        this.commit('PUT_COLLECTIVE_KEY_TO_LOCALSTORAGE', state.collective.key)
+        this.commit('PUT_COLLECTIVE_NAME_BY_KEY_TO_LOCALSTORAGE', state.collective)
       }
     },
     UNSET_COLLECTIVE(state) {

--- a/payshare/purchases/static/client/src/views/Login.vue
+++ b/payshare/purchases/static/client/src/views/Login.vue
@@ -67,7 +67,7 @@ export default {
         this.$bus.$emit('logged-in')
 
         this.password = null
-        this.$router.push('/transfers')
+        this.$router.push(`/${this.uuid}/transfers`)
       })
       .catch(error => {
         this.loading = false

--- a/payshare/purchases/static/client/src/views/Unknown.vue
+++ b/payshare/purchases/static/client/src/views/Unknown.vue
@@ -16,7 +16,12 @@
             <li v-for="prevKey in previousCollectiveKeys"
                 :key="prevKey">
                 <a :href="'/' + prevKey">
-                  {{ prevKey }}
+                  <span v-if="collectiveNameByKey[prevKey]">
+                    {{ collectiveNameByKey[prevKey] }}
+                  </span>
+                  <span v-else>
+                    {{ prevKey }}
+                  </span>
                 </a>
             </li>
           </ul>
@@ -34,9 +39,13 @@ export default {
     previousCollectiveKeys() {
       return this.$store.state.previousCollectiveKeys || []
     },
+    collectiveNameByKey() {
+      return this.$store.state.collectiveNameByKey
+    },
   },
   created() {
     this.$store.commit('LOAD_PREVIOUS_COLLECTIVE_KEYS_FROM_LOCALSTORAGE')
+    this.$store.commit('LOAD_COLLECTIVE_NAME_BY_KEY_MAP_FROM_LOCALSTORAGE')
   },
 }
 


### PR DESCRIPTION
Fixes #6 

Reloading page works properly now and we stay in the collective, no need to login again.

Pasting some other collective's URL will logout and need us to choose again, not ideal yet. Should redirect to login of that collective instead.